### PR TITLE
Fixed minor bugs and added functionality.

### DIFF
--- a/modesolverpy/mode_solver.py
+++ b/modesolverpy/mode_solver.py
@@ -317,6 +317,14 @@ class _ModeSolver(with_metaclass(abc.ABCMeta)):
                 e_str = ",".join([str(v) for v in e])
                 fs.write(e_str + "\n")
         return mode
+    
+    def _write_mode_to_file_details(self, mode, filename):
+        efieldarray = []
+        for e, y in zip(mode[::-1], self._structure.y[::-1]):
+            for a, x in zip(e, self._structure.x[::-1]):
+                efieldarray.append([x,y,a])
+        np.savetxt(filename, efieldarray, delimiter=',',fmt='%.4e%+.4ej, %.4e%+.4ej, %.4e%+.4ej')
+        return mode
 
     def _plot_n_effs(self, filename_n_effs, filename_te_fractions, xlabel, ylabel, title):
         args = {
@@ -545,7 +553,8 @@ class ModeSolverSemiVectorial(_ModeSolver):
 
         return r
 
-    def write_modes_to_file(self, filename="mode.dat", plot=True, analyse=True):
+    def write_modes_to_file(self, filename="mode.dat", plot=True, analyse=True,
+        details=False):
         """
         Writes the mode fields to a file and optionally plots them.
 
@@ -606,6 +615,9 @@ class ModeSolverSemiVectorial(_ModeSolver):
                         self.n_effs[i],
                         wavelength=self._structure._wl,
                     )
+            if details:
+                self._write_mode_to_file_details( mode, filename)
+       
 
         return self.modes
 
@@ -731,6 +743,7 @@ class ModeSolverFullyVectorial(_ModeSolver):
         filename="mode.dat",
         plot=True,
         fields_to_write=("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"),
+        details=False
     ):
         """
         Writes the mode fields to a file and optionally plots them.
@@ -795,5 +808,8 @@ class ModeSolverFullyVectorial(_ModeSolver):
                             area=area,
                             wavelength=self._structure._wl,
                         )
+                    if details:
+                        self._write_mode_to_file_details( mode, filename)
+       
 
         return self.modes

--- a/modesolverpy/mode_solver.py
+++ b/modesolverpy/mode_solver.py
@@ -570,6 +570,8 @@ class ModeSolverSemiVectorial(_ModeSolver):
                 diameter (MFD) and marks it on the output, and it
                 marks with a cross the maximum E-field value.
                 Default is `True`.
+            details (bool): 'True' if you want to save the x, y values in
+                addition to the electric field amplitudes.
 
         Returns:
             dict: A dictionary containing the effective indices
@@ -760,6 +762,8 @@ class ModeSolverFullyVectorial(_ModeSolver):
                 defining what part of the mode should be saved and
                 plotted.  By default, all six components are written
                 and plotted.
+            details (bool): 'True' if you want to save the x, y values in
+                addition to the electric field amplitudes.
 
         Returns:
             dict: A dictionary containing the effective indices

--- a/modesolverpy/structure_base.py
+++ b/modesolverpy/structure_base.py
@@ -133,7 +133,7 @@ class _AbstractStructure(with_metaclass(abc.ABCMeta)):
         '''
         if None not in (self.x_min, self.x_max, self.x_step) and \
                 self.x_min != self.x_max:
-            x = np.arange(self.x_min, self.x_max+self.x_step-self.y_step*0.1, self.x_step)
+            x = np.arange(self.x_min, self.x_max+self.x_step-self.x_step*0.1, self.x_step)
         else:
             x = np.array([])
         return x
@@ -369,7 +369,7 @@ class Slabs(_AbstractStructure):
         else:
             n_back = n_background
 
-        height_discretised = self.y_step*((height // self.y_step) + 1)
+        height_discretised = self.y_step*(height // self.y_step)
 
         y_min = self._next_start
         y_max = y_min + height_discretised


### PR DESCRIPTION
Thank you very much for the code, it has been a big help in my studies and research! I fixed some minor bugs, which might cause problems in very specific cases and added some functionality, if you want to include that.

(1) In structure_base.py on line 136, I changed a y_step to x_step (which has been mentioned in an issue as well), as it is inconsistent. The initial code causes errors if you use a non-uniform grid. There is also the fact that another stepsize is added to x, but not to y. I tried to fix this, but it caused further errors, so I assume this is on purpose.

(2) In structure_base.py on line 372, I removed a +1 stepsize for the discretized height. Even if you choose a stepsize for the layers, such that is correctly discretised (e.g. 10nm stepsize for a 100nm layer), this line of code will still add another self.y_step (in this case 10nm) to the layer thickness and cause it to be larger (110nm) instead. While this might not be an issue for small stepsizes or a low amount of layers, this causes problems for larger stepsizes or many layers, such as in Bragg-mirror structures.

(3) In mode_solver.py I added the functionality to save the x, y values in addition to the electric field amplitude. This was very useful for me in further simulations and I thought it might be useful for others. For now, it's very crude and simply overwrites the initially saved data, such that plotting still works the same, but it works.

If there is any reason as to why (1) and (2) have been done this way, please let me know! Thanks a lot!

Best regards
Alex

