### PR TITLE
Eliminated use of interp2d and scipy.sqrt to get things working with scipy 1.14.1.

### DIFF
--- a/modesolverpy/_mode_solver_lib.py
+++ b/modesolverpy/_mode_solver_lib.py
@@ -258,7 +258,7 @@ class _ModeSolverSemiVectorial():
             eigvals = eigs
             eigvecs = None
 
-        neff = self.wl * scipy.sqrt(eigvals) / (2 * numpy.pi)
+        neff = self.wl * numpy.sqrt(eigvals) / (2 * numpy.pi)
         if mode_profiles:
             phi = []
             for ieig in range(neigs):
@@ -970,7 +970,7 @@ class _ModeSolverVectorial():
                                         return_eigenvectors=mode_profiles,
                                         sigma=shift)
 
-        neffs = self.wl * scipy.sqrt(eigvals) / (2 * numpy.pi)
+        neffs = self.wl * numpy.sqrt(eigvals) / (2 * numpy.pi)
         if mode_profiles:
             Hxs = []
             Hys = []
@@ -1032,7 +1032,7 @@ class FDMode():
     def norm(self):
         x = centered1d(self.x)
         y = centered1d(self.y)
-        return scipy.sqrt(trapz2(self.intensity(), x=x, y=y))
+        return numpy.sqrt(trapz2(self.intensity(), x=x, y=y))
 
     def normalize(self):
         n = self.norm()

--- a/modesolverpy/structure_base.py
+++ b/modesolverpy/structure_base.py
@@ -165,9 +165,10 @@ class _AbstractStructure(with_metaclass(abc.ABCMeta)):
             returns the permittivity profile of the structure,
             interpolating if necessary.
         '''
-        interp_real = interpolate.interp2d(self.x, self.y, self.eps.real)
-        interp_imag = interpolate.interp2d(self.x, self.y, self.eps.imag)
-        interp = lambda x, y: interp_real(x, y) + 1.j*interp_imag(x, y)
+        interp_real = interpolate.RegularGridInterpolator((self.x, self.y), self.eps.real.T)
+        interp_imag = interpolate.RegularGridInterpolator((self.x, self.y), self.eps.imag.T)
+        interp = lambda x, y: (interp_real((x.reshape((1, -1)), y.reshape((-1, 1)))) + 
+                           1.j*interp_imag((x.reshape((1, -1)), y.reshape((-1, 1)))))
         return interp
 
     @property
@@ -177,7 +178,7 @@ class _AbstractStructure(with_metaclass(abc.ABCMeta)):
             returns the refractive index profile of the structure,
             interpolating if necessary.
         '''
-        return interpolate.interp2d(self.x, self.y, self.n)
+        return interpolate.RegularGridInterpolator((self.x, self.y), self.n)
 
     def _add_triangular_sides(self, xy_mask, angle, y_top_right, y_bot_left,
                               x_top_right, x_bot_left, n_material):
@@ -297,7 +298,7 @@ class Structure(_AbstractStructure):
         self.x_step = x_step
         self.y_step = y_step
         self.n_background = n_background
-        self._n = np.ones((self.y.size,self.x.size), 'complex_') * n_background
+        self._n = np.ones((self.y.size,self.x.size), 'complex') * n_background
 
     @property
     def n(self):


### PR DESCRIPTION
I had to make some changes to get example1 working with scipy 1.14.1. Here they are...